### PR TITLE
Implement dynamic version resolution for Krateo and providers

### DIFF
--- a/config/common.conf
+++ b/config/common.conf
@@ -7,7 +7,24 @@
 # ==============================================================================
 
 # Krateo installation (respects environment variable overrides)
-KRATEO_VERSION="${KRATEO_VERSION:-3.0.0-rc1}"
+# Dynamic version resolution: fetch latest from GitHub (including RCs)
+# To disable dynamic versioning, set KRATEO_VERSION explicitly
+# Examples:
+#   ./initialize_krateo.sh                      # Uses latest version (including RCs)
+#   KRATEO_VERSION=3.0.0 ./initialize_krateo.sh # Uses specific version
+#   KRATEO_INCLUDE_RC=false ./initialize_krateo.sh # Uses latest stable (no RCs)
+
+if [ -z "$KRATEO_VERSION" ]; then
+    # Dynamically fetch latest version from GitHub (includes RCs by default)
+    KRATEO_INCLUDE_RC="${KRATEO_INCLUDE_RC:-true}"
+    KRATEO_VERSION_DEFAULT="3.0.0-rc1"  # Fallback default
+    # Note: Actual version resolved in install_krateo_core.sh
+    KRATEO_VERSION="$KRATEO_VERSION_DEFAULT"
+else
+    # Use explicitly set version
+    KRATEO_INCLUDE_RC="${KRATEO_INCLUDE_RC:-true}"
+fi
+
 KRATEO_PROFILE="${KRATEO_PROFILE:-debug}"
 KRATEO_SYSTEM_NAMESPACE="${KRATEO_SYSTEM_NAMESPACE:-krateo-system}"
 DEMO_SYSTEM_NAMESPACE="${DEMO_SYSTEM_NAMESPACE:-demo-system}"
@@ -46,6 +63,21 @@ MARKETPLACE_REPO_URL="https://marketplace.krateo.io"
 # Frontend UI
 # Composition engine (core-provider, oasgen-provider)
 # Optional: FinOps stack, OPA policy engine
+
+# ============================================================================
+# Helm Chart Versions for Providers
+# Dynamic version resolution: fetch latest from Helm repositories
+# To use specific versions, override these environment variables:
+#   GITHUB_PROVIDER_KOG_REPO_VERSION=1.0.0
+#   GIT_PROVIDER_VERSION=0.10.1
+#   ARGOCD_VERSION=8.0.17
+# ============================================================================
+
+# Note: Versions are resolved dynamically in install_krateo_providers.sh
+# using the get_latest_helm_chart_version() function if not explicitly set
+GITHUB_PROVIDER_KOG_REPO_VERSION="${GITHUB_PROVIDER_KOG_REPO_VERSION:-1.0.0}"
+GIT_PROVIDER_VERSION="${GIT_PROVIDER_VERSION:-0.10.1}"
+ARGOCD_VERSION="${ARGOCD_VERSION:-8.0.17}"
 
 # ============================================================================
 # Service Port Mappings (NodePort)

--- a/setup/install_krateo_core.sh
+++ b/setup/install_krateo_core.sh
@@ -32,8 +32,19 @@ fi
 log_success "krateoctl is available"
 echo ""
 
+# Step 2b: Resolve KRATEO_VERSION dynamically if not explicitly set
+if [ "$KRATEO_VERSION" = "3.0.0-rc1" ] && [ -z "$KRATEO_VERSION_EXPLICIT" ]; then
+    log_info "Step 2b: Resolving latest Krateo version from GitHub..."
+    RESOLVED_VERSION=$(get_version "krateoplatformops" "releases" "3.0.0-rc1" "$KRATEO_INCLUDE_RC")
+    if [ -n "$RESOLVED_VERSION" ]; then
+        KRATEO_VERSION="$RESOLVED_VERSION"
+        log_success "Resolved version: $KRATEO_VERSION"
+    fi
+fi
+echo ""
+
 # Step 3: Install Krateo core via krateoctl
-log_info "Step 2: Installing Krateo core via krateoctl..."
+log_info "Step 3: Installing Krateo core via krateoctl..."
 log_info "Version: $KRATEO_VERSION | Profile: $KRATEO_PROFILE"
 echo ""
 
@@ -47,7 +58,7 @@ log_success "Krateo core installed successfully"
 echo ""
 
 # Step 4: Verify installation
-log_info "Step 3: Verifying Krateo installation..."
+log_info "Step 4: Verifying Krateo installation..."
 sleep 2
 
 KRATEO_INSTALLATION=$(kubectl get installation -n "$KRATEO_SYSTEM_NAMESPACE" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
@@ -59,7 +70,7 @@ fi
 echo ""
 
 # Step 5: Retrieve admin credentials
-log_info "Step 4: Retrieving admin credentials..."
+log_info "Step 5: Retrieving admin credentials..."
 ADMIN_PASSWORD=$(kubectl get secret admin-password -n "$KRATEO_SYSTEM_NAMESPACE" -o jsonpath="{.data.password}" 2>/dev/null | base64 -d 2>/dev/null)
 if [ -z "$ADMIN_PASSWORD" ]; then
     log_warn "⚠️  admin-password secret not found yet - may still be initializing"

--- a/setup/install_krateo_providers.sh
+++ b/setup/install_krateo_providers.sh
@@ -38,15 +38,42 @@ add_helm_repo "marketplace" "$MARKETPLACE_REPO_URL"
 log_success "Helm repositories added"
 echo ""
 
+# Step 2b: Resolve provider versions dynamically if not explicitly set
+log_info "Step 2b: Resolving latest provider versions..."
+if [ "$GITHUB_PROVIDER_KOG_REPO_VERSION" = "1.0.0" ] && [ -z "$GITHUB_PROVIDER_KOG_REPO_VERSION_EXPLICIT" ]; then
+    RESOLVED_VERSION=$(get_latest_helm_chart_version "marketplace/github-provider-kog-repo")
+    if [ -n "$RESOLVED_VERSION" ]; then
+        GITHUB_PROVIDER_KOG_REPO_VERSION="$RESOLVED_VERSION"
+        log_info "  ✓ github-provider-kog-repo: $GITHUB_PROVIDER_KOG_REPO_VERSION"
+    fi
+fi
+
+if [ "$GIT_PROVIDER_VERSION" = "0.10.1" ] && [ -z "$GIT_PROVIDER_VERSION_EXPLICIT" ]; then
+    RESOLVED_VERSION=$(get_latest_helm_chart_version "krateo/git-provider")
+    if [ -n "$RESOLVED_VERSION" ]; then
+        GIT_PROVIDER_VERSION="$RESOLVED_VERSION"
+        log_info "  ✓ git-provider: $GIT_PROVIDER_VERSION"
+    fi
+fi
+
+if [ "$ARGOCD_VERSION" = "8.0.17" ] && [ -z "$ARGOCD_VERSION_EXPLICIT" ]; then
+    RESOLVED_VERSION=$(get_latest_helm_chart_version "argo/argo-cd")
+    if [ -n "$RESOLVED_VERSION" ]; then
+        ARGOCD_VERSION="$RESOLVED_VERSION"
+        log_info "  ✓ argocd: $ARGOCD_VERSION"
+    fi
+fi
+echo ""
+
 # Step 3: Install or upgrade github-provider-kog-repo
-log_info "Step 2: Installing github-provider-kog-repo..."
+log_info "Step 3: Installing github-provider-kog-repo..."
 if helm list -n "$KRATEO_SYSTEM_NAMESPACE" | grep -q "^github-provider-kog-repo"; then
     log_info "Release already exists, upgrading..."
     if ! helm upgrade github-provider-kog-repo marketplace/github-provider-kog-repo \
         --namespace "$KRATEO_SYSTEM_NAMESPACE" \
         --wait \
         --timeout 5m \
-        --version 1.0.0; then
+        --version "$GITHUB_PROVIDER_KOG_REPO_VERSION"; then
         die "Failed to upgrade github-provider-kog-repo"
     fi
 else
@@ -55,7 +82,7 @@ else
         --create-namespace \
         --wait \
         --timeout 5m \
-        --version 1.0.0; then
+        --version "$GITHUB_PROVIDER_KOG_REPO_VERSION"; then
         die "Failed to install github-provider-kog-repo"
     fi
 fi
@@ -63,14 +90,14 @@ log_success "github-provider-kog-repo installed"
 echo ""
 
 # Step 4: Install or upgrade git-provider
-log_info "Step 3: Installing git-provider..."
+log_info "Step 4: Installing git-provider..."
 if helm list -n "$KRATEO_SYSTEM_NAMESPACE" | grep -q "^git-provider"; then
     log_info "Release already exists, upgrading..."
     if ! helm upgrade git-provider krateo/git-provider \
         --namespace "$KRATEO_SYSTEM_NAMESPACE" \
         --wait \
         --timeout 5m \
-        --version 0.10.1; then
+        --version "$GIT_PROVIDER_VERSION"; then
         die "Failed to upgrade git-provider"
     fi
 else
@@ -79,7 +106,7 @@ else
         --create-namespace \
         --wait \
         --timeout 5m \
-        --version 0.10.1; then
+        --version "$GIT_PROVIDER_VERSION"; then
         die "Failed to install git-provider"
     fi
 fi
@@ -87,14 +114,14 @@ log_success "git-provider installed"
 echo ""
 
 # Step 5: Install or upgrade ArgoCD
-log_info "Step 4: Installing ArgoCD..."
+log_info "Step 5: Installing ArgoCD..."
 if helm list -n "$KRATEO_SYSTEM_NAMESPACE" | grep -q "^argocd"; then
     log_info "Release already exists, upgrading..."
     if ! helm upgrade argocd argo/argo-cd \
         --namespace "$KRATEO_SYSTEM_NAMESPACE" \
         --wait \
         --timeout 5m \
-        --version 8.0.17; then
+        --version "$ARGOCD_VERSION"; then
         die "Failed to upgrade argocd"
     fi
 else
@@ -103,7 +130,7 @@ else
         --create-namespace \
         --wait \
         --timeout 5m \
-        --version 8.0.17; then
+        --version "$ARGOCD_VERSION"; then
         die "Failed to install argocd"
     fi
 fi

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -297,6 +297,127 @@ get_resources_by_status() {
 }
 
 # ============================================================================
+# Version Resolution Functions
+# ============================================================================
+
+# Fetch latest release from GitHub API (including pre-releases)
+# Tries releases endpoint first, falls back to tags endpoint
+# Usage: get_latest_github_release "krateoplatformops" "releases" ["include-rc"]
+get_latest_github_release() {
+    local owner="$1"
+    local repo="$2"
+    local include_rc="${3:-true}"
+    
+    if ! command -v jq &> /dev/null; then
+        log_error "jq is required for version resolution"
+        return 1
+    fi
+    
+    local response
+    local latest_tag
+    
+    # Try releases endpoint first
+    local api_url="https://api.github.com/repos/$owner/$repo/releases"
+    response=$(curl -s --max-time 10 "$api_url" 2>/dev/null)
+    
+    if [ -z "$response" ]; then
+        log_error "Failed to fetch releases from GitHub API for $owner/$repo"
+        return 1
+    fi
+    
+    # Check if we got releases
+    if [ "$include_rc" = "true" ]; then
+        latest_tag=$(echo "$response" | jq -r '.[0].tag_name' 2>/dev/null)
+    else
+        # Exclude pre-releases from releases endpoint
+        latest_tag=$(echo "$response" | jq -r '.[] | select(.prerelease == false) | .tag_name' 2>/dev/null | head -1)
+    fi
+    
+    # If no releases, try tags endpoint as fallback
+    if [ -z "$latest_tag" ] || [ "$latest_tag" = "null" ]; then
+        api_url="https://api.github.com/repos/$owner/$repo/tags"
+        response=$(curl -s --max-time 10 "$api_url" 2>/dev/null)
+        
+        if [ -n "$response" ] && [ "$response" != "[]" ]; then
+            if [ "$include_rc" = "true" ]; then
+                # Get latest tag (first in list)
+                latest_tag=$(echo "$response" | jq -r '.[0].name' 2>/dev/null)
+            else
+                # Filter out RC/alpha/beta/dev versions - keep only stable versions
+                latest_tag=$(echo "$response" | jq -r '.[] | select(.name | test("-rc|-alpha|-beta|-dev"; "i") | not) | .name' 2>/dev/null | head -1)
+                
+                # If no stable versions found, still return empty (don't fall back to RC)
+                if [ -z "$latest_tag" ] || [ "$latest_tag" = "null" ]; then
+                    return 1
+                fi
+            fi
+        fi
+    fi
+    
+    if [ -z "$latest_tag" ] || [ "$latest_tag" = "null" ]; then
+        return 1
+    fi
+    
+    # Clean up tag name (remove leading 'v' if present)
+    echo "$latest_tag" | sed 's/^v//'
+}
+
+# Fetch latest release with fallback to default version
+# Usage: get_version "krateoplatformops" "krateoctl" "0.1.0" "true"
+# NOTE: Only outputs the version to stdout (logging goes to stderr)
+get_version() {
+    local owner="$1"
+    local repo="$2"
+    local default_version="$3"
+    local include_rc="${4:-true}"
+    
+    if [ $# -lt 2 ]; then
+        log_error "get_version requires at least: owner repo [default_version] [include_rc]" >&2
+        return 1
+    fi
+    
+    local latest_version
+    latest_version=$(get_latest_github_release "$owner" "$repo" "$include_rc")
+    
+    # If fetch failed or returned empty, use default version
+    if [ -z "$latest_version" ]; then
+        log_warn "Failed to fetch latest release for $owner/$repo, using default: $default_version" >&2
+        echo "$default_version"
+        return 0
+    fi
+    
+    log_info "Latest version for $owner/$repo: $latest_version" >&2
+    echo "$latest_version"
+}
+
+# Get latest Helm chart version from Helm repository
+# Usage: get_latest_helm_chart_version "krateo/git-provider"
+# NOTE: Only outputs the version to stdout (logging goes to stderr)
+get_latest_helm_chart_version() {
+    local chart_name="$1"
+    local repo_name="${chart_name%%/*}"
+    local chart="${chart_name##*/}"
+    
+    if ! command -v helm &> /dev/null; then
+        log_error "helm is required for chart version resolution" >&2
+        return 1
+    fi
+    
+    # Ensure repo is updated (output to stderr)
+    helm repo update "$repo_name" > /dev/null 2>&1 || {
+        log_warn "Failed to update Helm repo: $repo_name" >&2
+        return 1
+    }
+    
+    # Search for latest version and only output version to stdout
+    helm search repo "$chart_name" --output json 2>/dev/null | \
+        jq -r '.[0].version' 2>/dev/null || {
+        log_error "Failed to find chart: $chart_name" >&2
+        return 1
+    }
+}
+
+# ============================================================================
 # Confirmation Functions
 # ============================================================================
 


### PR DESCRIPTION
This pull request introduces dynamic version resolution for Krateo core and its provider Helm charts, enabling automatic fetching of the latest available versions (including release candidates) unless a specific version is explicitly set. The version resolution logic is implemented in utility functions and integrated into the installation scripts, making the setup process more flexible and up-to-date by default.

The most important changes are:

**Dynamic Version Resolution for Krateo Core:**
* Updated `config/common.conf` to support dynamic determination of `KRATEO_VERSION`, with options to include or exclude release candidates and to override with a specific version if desired. The actual resolution is deferred to the install script.
* Modified `setup/install_krateo_core.sh` to resolve the latest Krateo version from GitHub if not explicitly set, using the new utility function.

**Dynamic Version Resolution for Provider Helm Charts:**
* Enhanced `config/common.conf` to allow dynamic resolution of provider chart versions (`GITHUB_PROVIDER_KOG_REPO_VERSION`, `GIT_PROVIDER_VERSION`, `ARGOCD_VERSION`), with the actual version determined at install time unless overridden.
* Updated `setup/install_krateo_providers.sh` to use the new version resolution utility for each provider, ensuring the latest chart versions are installed by default.

**Utility Functions for Version Resolution:**
* Added robust functions to `utils/common.sh` for fetching the latest GitHub releases (with or without pre-releases) and the latest Helm chart versions, handling errors and fallbacks gracefully.

**General Improvements:**
* Adjusted step numbering and log messages in install scripts for clarity and consistency. [[1]](diffhunk://#diff-165bb5594456c13e6473191730a620ea87c66aa3ffb17eb955f6f776c62031a2L50-R61) [[2]](diffhunk://#diff-165bb5594456c13e6473191730a620ea87c66aa3ffb17eb955f6f776c62031a2L62-R73) [[3]](diffhunk://#diff-7e7a935c2d200ba9ae750003c79e0e3ffa218094c2071ecba82129c13c783db0L58-R100) [[4]](diffhunk://#diff-7e7a935c2d200ba9ae750003c79e0e3ffa218094c2071ecba82129c13c783db0L82-R124) [[5]](diffhunk://#diff-7e7a935c2d200ba9ae750003c79e0e3ffa218094c2071ecba82129c13c783db0L106-R133)

These changes make the installation process more robust and reduce manual maintenance for version updates.